### PR TITLE
Allow re-compilation when source or compile flags change

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -37,11 +37,17 @@ package yasm_package do
   action :upgrade
 end
 
+creates_x264 = "#{node[:x264][:prefix]}/bin/x264"
+
+file "#{creates_x264}" do
+	action :nothing
+end
+
 git "#{Chef::Config[:file_cache_path]}/x264" do
   repository node[:x264][:git_repository]
   reference node[:x264][:git_revision]
   action :sync
-  notifies :run, "bash[compile_x264]"
+  notifies :delete, "file[#{creates_x264}]"
 end
 
 # Write the flags used to compile the application to disk. If the flags
@@ -54,7 +60,7 @@ template "#{Chef::Config[:file_cache_path]}/x264-compiled_with_flags" do
   variables(
     :compile_flags => node[:x264][:compile_flags]
   )
-  notifies :run, "bash[compile_x264]"
+  notifies :delete, "file[#{creates_x264}]"
 end
 
 bash "compile_x264" do
@@ -63,5 +69,5 @@ bash "compile_x264" do
     ./configure --prefix=#{node[:x264][:prefix]} #{node[:x264][:compile_flags].join(' ')}
     make clean && make && make install
   EOH
-  action :nothing
+  creates "#{creates_x264}"
 end

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -47,7 +47,7 @@ git "#{Chef::Config[:file_cache_path]}/x264" do
   repository node[:x264][:git_repository]
   reference node[:x264][:git_revision]
   action :sync
-  notifies :delete, "file[#{creates_x264}]"
+  notifies :delete, "file[#{creates_x264}]", :immediately
 end
 
 # Write the flags used to compile the application to disk. If the flags
@@ -60,7 +60,7 @@ template "#{Chef::Config[:file_cache_path]}/x264-compiled_with_flags" do
   variables(
     :compile_flags => node[:x264][:compile_flags]
   )
-  notifies :delete, "file[#{creates_x264}]"
+  notifies :delete, "file[#{creates_x264}]", :immediately
 end
 
 bash "compile_x264" do

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -63,5 +63,5 @@ bash "compile_x264" do
     ./configure --prefix=#{node[:x264][:prefix]} #{node[:x264][:compile_flags].join(' ')}
     make clean && make && make install
   EOH
-  creates "#{node[:x264][:prefix]}/bin/x264"
+  action :nothing
 end


### PR DESCRIPTION
Hi,

when making use of "creates" no recompilation is triggered when new code is pulled down nor when compile flags change. Via action :nothing the compile is triggered via the notifies :run.

Let me know if you have any questions or comments, thanks in advance!

Kind regards,
David
