### PR TITLE
Need to fix git repo URL

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,7 +6,7 @@
 #
 
 default['x264']['install_method'] = :source
-default['x264']['git_repository'] = "git://git.videolan.org/x264"
+default['x264']['git_repository'] = "git://git.videolan.org/x264.git"
 default['x264']['prefix'] = "/usr/local"
 default['x264']['compile_flags'] = ["--enable-static"]
 


### PR DESCRIPTION
Hi,

I noticed wrong git repo URL in attributes/default.rb

default['x264']['git_repository'] = "git://git.videolan.org/x264"

it should be

default['x264']['git_repository'] = "git://git.videolan.org/x264.git"
